### PR TITLE
Fix removeUniqueJobData when a number is passed as ID.

### DIFF
--- a/index.js
+++ b/index.js
@@ -107,6 +107,8 @@ Job.removeUniqueJobData = function(id, done) {
             //remove given job from unique job data
             //we have an id, lets find the key name.
             //
+            // all redis values are strings, to make === work, have to convert to string.
+            id = id.toString();
             var unique = Object.keys(uniqueJobsData).filter(function(key) {
                 return uniqueJobsData[key] === id;
             })[0];


### PR DESCRIPTION
when working on kue-scheduler, I noticed that the code passes an integer value in rather than a number in a string, because we're doing the match by value with === that would return false. In order to be explicit, all id's get cast to string so that === will still work.