### PR TITLE
only delete when there is a unique name

### DIFF
--- a/index.js
+++ b/index.js
@@ -113,12 +113,16 @@ Job.removeUniqueJobData = function(id, done) {
                 return uniqueJobsData[key] === id;
             })[0];
 
-            Job
-                .client
-                .hdel(key, unique,
-                    function(error /*, response*/ ) {
-                        next(error);
-                    });
+            if (unique) {
+                return Job
+                    .client
+                    .hdel(key, unique,
+                        function(error /*, response*/ ) {
+                            next(error);
+                        });
+            }
+            
+            next(null);
         },
 
         function reloadUniqueJobsData(next) {


### PR DESCRIPTION
sometimes, `unique` is `null` which results to

```
node_redis: Deprecated: The HDEL command contains a "undefined" argument.
This is converted to a "undefined" string now and will return an error from v.3.0 on.
Please handle this in your code to make sure everything works as you intended it to.
```

in order to prevent this, we need to handle it here