### PR TITLE
fix HDEL undefined argument

### DIFF
--- a/index.js
+++ b/index.js
@@ -121,7 +121,7 @@ Job.removeUniqueJobData = function (id, done) {
 
       Job
         .client
-        .hdel(key, unique, function (error /*, response*/ ) {
+        .hdel(key, unique || '', function (error /*, response*/ ) {
           next(error);
         });
     },


### PR DESCRIPTION
A fix for

```
node_redis: Deprecated: The HDEL command contains a "undefined" argument.
This is converted to a "undefined" string now and will return an error from v.3.0 on.
Please handle this in your code to make sure everything works as you intended it to.
```

Problem arises when the job is not unique, therefore making `unique` in line 118 `undefined`. a quick fix would be to use an empty string when it is `undefined`.